### PR TITLE
Use Node.js 24 in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
       - name: Update npm
         run: npm install -g npm@latest
       - name: Update and Publish


### PR DESCRIPTION
Fixes the release workflow error (see https://github.com/nodejs/node/issues/62425)